### PR TITLE
use rsplit to be more concise

### DIFF
--- a/splice/environment.py
+++ b/splice/environment.py
@@ -17,9 +17,7 @@ class EnvironmentUninitializedError(Exception):
 
 
 def load_config_obj(obj_name):
-    tokens = obj_name.split(".")
-    module_name = ".".join(tokens[:-1])
-    class_name = tokens[-1]
+    module_name, class_name = obj_name.rsplit(".", 1)
     module = importlib.import_module(module_name)
     return getattr(module, class_name)
 


### PR DESCRIPTION
 when extracting module and class name from config string

@oyiptong or @tspurway 