### PR TITLE
Allow explanation with optional replacements

### DIFF
--- a/splice/ingest.py
+++ b/splice/ingest.py
@@ -85,11 +85,10 @@ payload_schema = {
                         "maxLength": 255,
                     },
                     "explanation": {
-                        # e.g: "Suggested for %1$S enthusiasts who visit sites
-                        # like %2$S". adgroup_name and site_name are not order
-                        # sensitive.
+                        # example: "Suggested for %1$S enthusiasts who visit 
+                        # sites like %2$S". Both adgroup_name and site_name
+                        # are optiobal
                         "type": "string",
-                        "pattern": "^.*%1\$S.*%2\$S.*$|^.*%2\$S.*%1\$S.*$",
                         "maxLength": 255,
                     }
                 },

--- a/splice/ingest.py
+++ b/splice/ingest.py
@@ -85,7 +85,7 @@ payload_schema = {
                         "maxLength": 255,
                     },
                     "explanation": {
-                        # example: "Suggested for %1$S enthusiasts who visit 
+                        # example: "Suggested for %1$S enthusiasts who visit
                         # sites like %2$S". Both adgroup_name and site_name
                         # are optiobal
                         "type": "string",

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -226,13 +226,10 @@ class TestIngestLinks(BaseTestCase):
         return {"US/en-US": [tile]}
 
     def test_explanation_invalid_data(self):
-        # tests invalid templates
-        tile = self._make_dist({"explanation": "An incomplete explanation %1$S"})
-        assert_raises(ValidationError, ingest_links, tile, self.channels[0].id)
         tile = self._make_dist({"explanation": "A huge template %1$S, %2$S" * 100})
         assert_raises(ValidationError, ingest_links, tile, self.channels[0].id)
 
-    def test_explanation_template_sanity_check(self):
+    def test_explanation_template_sanitization(self):
         # test templates with html tags
         tile = self._make_dist({
             "adgroup_name": "<script>Technology</script>",


### PR DESCRIPTION
This PR refers to [Bug 1167404](https://bugzilla.mozilla.org/show_bug.cgi?id=1167404) - Allow for custom explanation with optional replacement targets