### PR TITLE
Add automated tests for the 'hello' channel

### DIFF
--- a/scripts/tile_index_crawl.py
+++ b/scripts/tile_index_crawl.py
@@ -66,6 +66,7 @@ def main():
         'desktop',
         'android',
         'desktop-prerelease',
+        'hello',
     ]
 
     if len(args) == 1:


### PR DESCRIPTION
This refers to [Bug 1184208 ](https://bugzilla.mozilla.org/show_bug.cgi?id=1184208) Update automated tests for onyx/splice to include 'hello' channel