### PR TITLE
Fix for Account API when all fields arent sent (PUT).

### DIFF
--- a/splice/queries/account.py
+++ b/splice/queries/account.py
@@ -44,13 +44,7 @@ def update_account(session, account_id, record):
     if account is None:
         raise NoResultFound('Account not found found')
 
-    if 'name' in record:
-        account.name = record['name']
-
-    if 'email' in record:
-        account.email = record['email']
-
-    if 'phone' in record:
-        account.phone = record['phone']
+    for key, val in record.items():
+        setattr(account, key, val)
 
     return row_to_dict(account)

--- a/splice/web/api/account.py
+++ b/splice/web/api/account.py
@@ -27,9 +27,11 @@ class AccountListAPI(Resource):
         self.reqparse.add_argument('name', type=unicode, required=True,
                                    help='Name of the new account', location='json')
         self.reqparse.add_argument('email', type=str, required=False,
-                                   help='Email address', location='json')
+                                   help='Email address', location='json',
+                                   store_missing=False)
         self.reqparse.add_argument('phone', type=str, required=False,
-                                   help='Phone number', location='json')
+                                   help='Phone number', location='json',
+                                   store_missing=False)
 
         super(AccountListAPI, self).__init__()
 
@@ -56,9 +58,11 @@ class AccountAPI(Resource):
         self.reqparse.add_argument('name', type=unicode, required=False,
                                    help='Name of the new account', location='json')
         self.reqparse.add_argument('email', type=str, required=False,
-                                   help='Email address', location='json')
+                                   help='Email address', location='json',
+                                   store_missing=False)
         self.reqparse.add_argument('phone', type=str, required=False,
-                                   help='Phone number', location='json')
+                                   help='Phone number', location='json',
+                                   store_missing=False)
 
         super(AccountAPI, self).__init__()
 

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -107,3 +107,25 @@ class TestAccountAPI(BaseTestCase):
         del account['id']
         del account['created_at']
         assert_equal(account, new_account_data)
+
+    def test_put_without_optional_fields(self):
+        """Test PUTing just the required fields."""
+        new_account_data = {
+            'name': 'New Account Name',
+        }
+
+        # Create an account.
+        with session_scope() as session:
+            account_id = insert_account(session, self.account_data)['id']
+
+        # Update the account with the new data.
+        url = url_for('api.account.account', account_id=account_id)
+        data = json.dumps(new_account_data)
+        response = self.client.put(url, data=data, content_type='application/json')
+        assert_equal(response.status_code, 200)
+
+        # Verify the data. Make sure the fields not sent don't get updated (nulled).
+        account = get_account(account_id)
+        assert_equal(account['name'], new_account_data['name'])
+        assert_equal(account['email'], self.account_data['email'])
+        assert_equal(account['phone'], self.account_data['phone'])


### PR DESCRIPTION
Uncovered this little bug while testing the campaign API. The issue was that the request parser defaults missing values to None by default.

r? @ncloudioj 