### PR TITLE
Refactor the return format

### DIFF
--- a/splice/web/api/adgroup.py
+++ b/splice/web/api/adgroup.py
@@ -63,7 +63,7 @@ class AdgroupListAPI(Resource):
         if len(adgroups) == 0:
             return {"message": "No adgroups found"}, 404
         else:
-            return {"message": marshal(adgroups, adgroup_fields)}
+            return {"results": marshal(adgroups, adgroup_fields)}
 
     def post(self):
         args = self.reqparse.parse_args()
@@ -73,7 +73,7 @@ class AdgroupListAPI(Resource):
         except InvalidRequestError as e:
             return {"message": e.message}, 400
         else:
-            return {"message": marshal(new, adgroup_fields)}, 201
+            return {"result": marshal(new, adgroup_fields)}, 201
 
 
 class AdgroupAPI(Resource):
@@ -108,7 +108,7 @@ class AdgroupAPI(Resource):
         if adgroup is None:
             return {"message": "Item is missing"}, 404
         else:
-            return {"message": marshal(adgroup, adgroup_fields)}
+            return {"result": marshal(adgroup, adgroup_fields)}
 
     def put(self, adgroup_id):
         args = self.reqparse.parse_args()
@@ -120,7 +120,7 @@ class AdgroupAPI(Resource):
         except InvalidRequestError as e:
             return {"message": e.message}, 400
         else:
-            return {"message": marshal(adgroup, adgroup_fields)}, 200
+            return {"result": marshal(adgroup, adgroup_fields)}, 200
 
 
 api.add_resource(AdgroupListAPI, '/adgroups', endpoint='adgroups')

--- a/splice/web/api/tile.py
+++ b/splice/web/api/tile.py
@@ -66,7 +66,7 @@ class TileListAPI(Resource):
         if len(tiles) == 0:
             return {"message": "No tiles found"}, 404
         else:
-            return {"message": marshal(tiles, tile_fields)}
+            return {"results": marshal(tiles, tile_fields)}
 
     def post(self):
         """ HTTP end point to create new tile. Note the initial status of a new
@@ -86,7 +86,7 @@ class TileListAPI(Resource):
         except InvalidRequestError as e:
             return {"message": e.message}, 400
         else:
-            return {"message": marshal(new, tile_fields)}, 201
+            return {"result": marshal(new, tile_fields)}, 201
 
 
 class TileAPI(Resource):
@@ -104,7 +104,7 @@ class TileAPI(Resource):
         if tile is None:
             return {"message": "No tile found"}, 404
         else:
-            return {"message": marshal(tile, tile_fields)}
+            return {"result": marshal(tile, tile_fields)}
 
     def put(self, tile_id):
         args = self.reqparse.parse_args()
@@ -114,7 +114,7 @@ class TileAPI(Resource):
         except NoResultFound as e:
             return {"message": e.message}, 404
         else:
-            return {"message": marshal(tile, tile_fields)}, 200
+            return {"result": marshal(tile, tile_fields)}, 200
 
 
 api.add_resource(TileListAPI, '/tiles', endpoint='tiles')

--- a/tests/api/test_adgroup.py
+++ b/tests/api/test_adgroup.py
@@ -31,7 +31,7 @@ class TestAdgroup(BaseTestCase):
             response = self.client.get(url)
             assert_equal(response.status_code, 200)
             resp = json.loads(response.data)
-            assert_equal(len(resp["message"]), len(adgroups))
+            assert_equal(len(resp["results"]), len(adgroups))
 
     def test_post_and_get(self):
         """ Test for HTTP POST and GET
@@ -40,12 +40,12 @@ class TestAdgroup(BaseTestCase):
         data = json.dumps(self.new_adgroup)
         response = self.client.post(url, data=data, content_type="application/json")
         assert_equal(response.status_code, 201)
-        new = json.loads(response.data)["message"]
+        new = json.loads(response.data)["result"]
 
         url = url_for('api.adgroup.adgroup', adgroup_id=new["id"])
         response = self.client.get(url)
         resp = json.loads(response.data)
-        assert_equal(new, resp["message"])
+        assert_equal(new, resp["result"])
 
     def test_post_duplicate(self):
         """ Test HTTP POST the same data twice, it should reject the second one as
@@ -87,7 +87,7 @@ class TestAdgroup(BaseTestCase):
         data = json.dumps(self.new_adgroup)
         response = self.client.post(url, data=data, content_type="application/json")
         assert_equal(response.status_code, 201)
-        new = json.loads(response.data)["message"]
+        new = json.loads(response.data)["result"]
 
         url = url_for('api.adgroup.adgroup', adgroup_id=new["id"])
         new["name"] = "new_name"
@@ -96,12 +96,12 @@ class TestAdgroup(BaseTestCase):
         data = json.dumps(new)
         response = self.client.put(url, data=data, content_type="application/json")
         assert_equal(response.status_code, 200)
-        updated = json.loads(response.data)["message"]
+        updated = json.loads(response.data)["result"]
 
         url = url_for('api.adgroup.adgroup', campaign_id=self.new_campaign_id, adgroup_id=new["id"])
         response = self.client.get(url)
         resp = json.loads(response.data)
-        assert_equal(updated, resp["message"])
+        assert_equal(updated, resp["result"])
 
     def test_http_put_404(self):
         """ Test the failure case of HTTP PUT. Editing a missing adgroup ends up with a 404 error
@@ -123,7 +123,7 @@ class TestAdgroup(BaseTestCase):
         data = json.dumps(self.new_adgroup)
         response = self.client.post(url, data=data, content_type="application/json")
         assert_equal(response.status_code, 201)
-        new_adgroup = json.loads(response.data)["message"]
+        new_adgroup = json.loads(response.data)["result"]
 
         url = url_for('api.adgroup.adgroup', adgroup_id=new_adgroup["id"])
         new_adgroup["type"] = "suggested"

--- a/tests/api/test_tile.py
+++ b/tests/api/test_tile.py
@@ -32,7 +32,7 @@ class TestTile(BaseTestCase):
             response = self.client.get(url)
             assert_equal(response.status_code, 200)
             resp = json.loads(response.data)
-            assert_equal(len(resp["message"]), len(tiles))
+            assert_equal(len(resp["results"]), len(tiles))
 
     def test_get_tiles_404(self):
         """ Test the failure case of HTTP GET
@@ -48,12 +48,12 @@ class TestTile(BaseTestCase):
         data = json.dumps(self.new_tile)
         response = self.client.post(url, data=data, content_type="application/json")
         assert_equal(response.status_code, 201)
-        new = json.loads(response.data)["message"]
+        new = json.loads(response.data)["result"]
 
         url = url_for('api.tile.tile', adgroup_id=self.new_adgroup_id, tile_id=new["id"])
         response = self.client.get(url)
         resp = json.loads(response.data)
-        assert_equal(new, resp["message"])
+        assert_equal(new, resp["result"])
 
     def test_post_400_missing_argument(self):
         """ Test the failure case of HTTP POST
@@ -99,19 +99,19 @@ class TestTile(BaseTestCase):
         data = json.dumps(self.new_tile)
         response = self.client.post(url, data=data, content_type="application/json")
         assert_equal(response.status_code, 201)
-        new = json.loads(response.data)["message"]
+        new = json.loads(response.data)["result"]
 
         url = url_for('api.tile.tile', tile_id=new["id"])
         new["status"] = "approved"
         data = json.dumps(new)
         response = self.client.put(url, data=data, content_type="application/json")
         assert_equal(response.status_code, 200)
-        updated = json.loads(response.data)["message"]
+        updated = json.loads(response.data)["result"]
 
         url = url_for('api.tile.tile', tile_id=new["id"])
         response = self.client.get(url)
         resp = json.loads(response.data)
-        assert_equal(updated, resp["message"])
+        assert_equal(updated, resp["result"])
 
     def test_http_put_404(self):
         """ Test the failure case of HTTP PUT. Editing a missing tile ends up with a 404 error
@@ -133,7 +133,7 @@ class TestTile(BaseTestCase):
         data = json.dumps(self.new_tile)
         response = self.client.post(url, data=data, content_type="application/json")
         assert_equal(response.status_code, 201)
-        new_tile = json.loads(response.data)["message"]
+        new_tile = json.loads(response.data)["result"]
 
         url = url_for('api.tile.tile', tile_id=new_tile["id"])
         del new_tile["status"]


### PR DESCRIPTION
Using "results" for multiple return values, and "result" for single ones.

r? @rlr 