### PR TITLE
Return an empty set when http GET api/resource/?missing_parent_id

### DIFF
--- a/splice/web/api/adgroup.py
+++ b/splice/web/api/adgroup.py
@@ -71,10 +71,7 @@ class AdgroupListAPI(Resource):
     def get(self):
         args = self.reqparse_get.parse_args()
         adgroups = get_adgroups_by_campaign_id(args['campaign_id'])
-        if len(adgroups) == 0:
-            return {"message": "No adgroups found"}, 404
-        else:
-            return {"results": marshal(adgroups, adgroup_fields)}
+        return {"results": marshal(adgroups, adgroup_fields)}
 
     def post(self):
         args = self.reqparse.parse_args()

--- a/splice/web/api/tile.py
+++ b/splice/web/api/tile.py
@@ -69,10 +69,7 @@ class TileListAPI(Resource):
     def get(self):
         args = self.reqparse_get.parse_args()
         tiles = get_tiles_by_adgroup_id(args['adgroup_id'])
-        if len(tiles) == 0:
-            return {"message": "No tiles found"}, 404
-        else:
-            return {"results": marshal(tiles, tile_fields)}
+        return {"results": marshal(tiles, tile_fields)}
 
     def post(self):
         """ HTTP end point to create new tile. Note the initial status of a new

--- a/tests/api/test_adgroup.py
+++ b/tests/api/test_adgroup.py
@@ -48,6 +48,15 @@ class TestAdgroup(BaseTestCase):
             resp = json.loads(response.data)
             assert_equal(len(resp["results"]), len(adgroups))
 
+    def test_get_adgroups_by_missing_campaign_id(self):
+        """ Test for getting adgroups for a missing campaign id
+        """
+        url = url_for('api.adgroup.adgroups', campaign_id=1234)
+        response = self.client.get(url)
+        assert_equal(response.status_code, 200)
+        resp = json.loads(response.data)
+        assert_equal(len(resp["results"]), 0)
+
     def test_post_and_get(self):
         """ Test for HTTP POST and GET
         """

--- a/tests/api/test_tile.py
+++ b/tests/api/test_tile.py
@@ -48,12 +48,13 @@ class TestTile(BaseTestCase):
             resp = json.loads(response.data)
             assert_equal(len(resp["results"]), len(tiles))
 
-    def test_get_tiles_404(self):
-        """ Test the failure case of HTTP GET
-        """
+    def test_get_tiles_for_missing_agroups(self):
+        """ Test for getting tiles for a missing adgroup id """
         url = url_for('api.tile.tiles', adgroup_id=10001)
         response = self.client.get(url)
-        assert_equal(response.status_code, 404)
+        assert_equal(response.status_code, 200)
+        resp = json.loads(response.data)
+        assert_equal(len(resp["results"]), 0)
 
     def test_post_and_get(self):
         """ Test for HTTP POST and GET


### PR DESCRIPTION
This PR is to unify the HTTP response when attempting GET a missing resource.

r? @rlr 