### PR TITLE
Use Flask-Cors to support CORS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ dateutils==0.6.6
 bleach==1.4.1
 tld==0.7.3
 flask-restful==0.3.4
+Flask-Cors==2.1.0

--- a/splice/environment.py
+++ b/splice/environment.py
@@ -7,6 +7,7 @@ from mock import Mock
 from flask import Flask
 from flask.ext.sqlalchemy import SQLAlchemy
 from flask.ext.migrate import Migrate
+from flask.ext.cors import CORS
 
 CONFIG_PATH_LOCATIONS = ['/etc/splice', os.path.abspath(os.path.dirname(__file__))]
 
@@ -66,6 +67,7 @@ class Environment(object):
         self.config = config_obj
         app = Flask('splice')
         app.config.from_object(config)
+        CORS(app, resources={r'/api/*': {"origins": "*"}})
 
         if app.config['ENVIRONMENT'] not in app.config['STATIC_ENABLED_ENVS']:
             app.config['STATIC_FOLDER'] = None

--- a/splice/web/api/account.py
+++ b/splice/web/api/account.py
@@ -1,6 +1,5 @@
 from flask import Blueprint
 from flask_restful import Api, Resource, marshal, fields, reqparse
-from flask_restful.utils import cors
 from sqlalchemy.exc import IntegrityError
 
 from sqlalchemy.orm.exc import NoResultFound
@@ -10,9 +9,7 @@ from splice.queries.account import (
 
 
 account_bp = Blueprint('api.account', __name__, url_prefix='/api')
-api = Api(account_bp,
-          decorators=[cors.crossdomain(origin='*', headers=['Content-Type'])])
-
+api = Api(account_bp)
 
 account_fields = {
     'id': fields.Integer,
@@ -46,10 +43,6 @@ class AccountListAPI(Resource):
         accounts = get_accounts()
         return {"results": marshal(accounts, account_fields)}
 
-    def options(self):
-        """Placeholder for flask-restful cors"""
-        pass  # pragma: no cover
-
     def post(self):
         """Creates an account."""
         args = self.reqparse.parse_args()
@@ -79,10 +72,6 @@ class AccountAPI(Resource):
                                    store_missing=False)
 
         super(AccountAPI, self).__init__()
-
-    def options(self):
-        """Placeholder for flask-restful cors"""
-        pass  # pragma: no cover
 
     def get(self, account_id):
         account = get_account(account_id)

--- a/splice/web/api/adgroup.py
+++ b/splice/web/api/adgroup.py
@@ -1,6 +1,5 @@
 from flask import Blueprint
 from flask_restful import Api, Resource, marshal, fields, reqparse
-from flask_restful.utils import cors
 
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import InvalidRequestError
@@ -12,8 +11,7 @@ from splice.models import Adgroup
 
 
 adgroup_bp = Blueprint('api.adgroup', __name__, url_prefix='/api')
-api = Api(adgroup_bp,
-          decorators=[cors.crossdomain(origin='*', headers=['Content-Type'])])
+api = Api(adgroup_bp)
 
 adgroup_fields = {
     'id': fields.Integer,
@@ -64,10 +62,6 @@ class AdgroupListAPI(Resource):
 
         super(AdgroupListAPI, self).__init__()
 
-    def options(self):
-        """Placeholder for flask-restful cors"""
-        pass  # pragma: no cover
-
     def get(self):
         args = self.reqparse_get.parse_args()
         adgroups = get_adgroups_by_campaign_id(args['campaign_id'])
@@ -111,10 +105,6 @@ class AdgroupAPI(Resource):
                                    help='Adgroup status', location='json',
                                    store_missing=False)
         super(AdgroupAPI, self).__init__()
-
-    def options(self):
-        """Placeholder for flask-restful cors"""
-        pass  # pragma: no cover
 
     def get(self, adgroup_id):
         adgroup = get_adgroup(adgroup_id)

--- a/splice/web/api/campaign.py
+++ b/splice/web/api/campaign.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 from flask import Blueprint
 from flask_restful import Api, Resource, marshal, fields, reqparse
-from flask_restful.utils import cors
 from sqlalchemy.exc import IntegrityError
 
 from sqlalchemy.orm.exc import NoResultFound
@@ -12,9 +11,7 @@ from splice.queries.campaign import (
 
 
 campaign_bp = Blueprint('api.campaign', __name__, url_prefix='/api')
-api = Api(campaign_bp,
-          decorators=[cors.crossdomain(origin='*', headers=['Content-Type'])])
-
+api = Api(campaign_bp)
 
 campaign_fields = {
     'id': fields.Integer,
@@ -58,10 +55,6 @@ class CampaignListAPI(Resource):
             'account_id', type=int, required=True, help='Account ID', location='args')
 
         super(CampaignListAPI, self).__init__()
-
-    def options(self):
-        """Placeholder for flask-restful cors"""
-        pass  # pragma: no cover
 
     def get(self):
         """Returns all the campaigns.
@@ -107,10 +100,6 @@ class CampaignAPI(Resource):
                                        store_missing=False)
 
         super(CampaignAPI, self).__init__()
-
-    def options(self):
-        """Placeholder for flask-restful cors"""
-        pass  # pragma: no cover
 
     def get(self, campaign_id):
         """Returns the campaign with given campaign_id."""

--- a/splice/web/api/tile.py
+++ b/splice/web/api/tile.py
@@ -2,7 +2,6 @@ import jsonschema
 
 from flask import Blueprint
 from flask_restful import Api, Resource, marshal, fields, reqparse
-from flask_restful.utils import cors
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import InvalidRequestError
 from splice.schemas import API_TILE_SCHEMA_POST, API_TILE_SCHEMA_PUT
@@ -13,8 +12,7 @@ from splice.queries.tile import (
 
 
 tile_bp = Blueprint('api.tile', __name__, url_prefix='/api')
-api = Api(tile_bp,
-          decorators=[cors.crossdomain(origin='*', headers=['Content-Type'])])
+api = Api(tile_bp)
 
 tile_fields = {
     'id': fields.Integer,
@@ -62,10 +60,6 @@ class TileListAPI(Resource):
                                        help='Adgroup ID', location='args')
         super(TileListAPI, self).__init__()
 
-    def options(self):
-        """Placeholder for flask-restful cors"""
-        pass  # pragma: no cover
-
     def get(self):
         args = self.reqparse_get.parse_args()
         tiles = get_tiles_by_adgroup_id(args['adgroup_id'])
@@ -106,10 +100,6 @@ class TileAPI(Resource):
         self.reqparse.add_argument('title_bg_color', type=str, required=False, store_missing=False,
                                    help='Background color of title', location='json')
         super(TileAPI, self).__init__()
-
-    def options(self):
-        """Placeholder for flask-restful cors"""
-        pass  # pragma: no cover
 
     def get(self, tile_id):
         tile = get_tile(tile_id)

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -3,7 +3,7 @@
 from tests.base import BaseTestCase
 
 from flask import url_for, json
-from nose.tools import assert_equal, assert_true
+from nose.tools import assert_equal
 
 from splice.queries.account import insert_account, get_account
 from splice.queries.common import session_scope
@@ -26,15 +26,20 @@ class TestAccountAPI(BaseTestCase):
         """Test the support for CORS"""
         url = url_for('api.account.accounts')
         data = json.dumps(self.account_data)
-        res = self.client.post(url, data=data, content_type='application/json')
+        res = self.client.post(url,
+                               data=data,
+                               headers={"Origin": "foo.com"},
+                               content_type='application/json')
         assert_equal(res.status_code, 201)
-        assert_equal(res.headers['Access-Control-Allow-Origin'], '*')
-        assert_equal(res.headers['Access-Control-Max-Age'], '21600')
-        assert_true('HEAD' in res.headers['Access-Control-Allow-Methods'])
-        assert_true('POS' in res.headers['Access-Control-Allow-Methods'])
-        assert_true('GET' in res.headers['Access-Control-Allow-Methods'])
-        assert_true('OPTIONS' in res.headers['Access-Control-Allow-Methods'])
-        assert_true('CONTENT-TYPE' in res.headers['Access-Control-Allow-Headers'])
+        assert_equal(res.headers['Access-Control-Allow-Origin'], 'foo.com')
+
+        # test CORS gets set properly in failures
+        res = self.client.post(url,
+                               data=data,
+                               headers={"Origin": "foo.com"},
+                               content_type='application/json')
+        assert_equal(res.status_code, 400)
+        assert_equal(res.headers['Access-Control-Allow-Origin'], 'foo.com')
 
     def test_get_accounts(self):
         """Test getting the list of accounts via API (GET)."""

--- a/tests/api/test_adgroup.py
+++ b/tests/api/test_adgroup.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equal, assert_true
+from nose.tools import assert_equal
 from flask import url_for, json
 from tests.base import BaseTestCase
 from tests.populate_database import parse_csv
@@ -28,15 +28,20 @@ class TestAdgroup(BaseTestCase):
         """Test the support for CORS"""
         url = url_for('api.adgroup.adgroups')
         data = json.dumps(self.new_adgroup)
-        res = self.client.post(url, data=data, content_type='application/json')
+        res = self.client.post(url,
+                               data=data,
+                               headers={"Origin": "foo.com"},
+                               content_type='application/json')
         assert_equal(res.status_code, 201)
-        assert_equal(res.headers['Access-Control-Allow-Origin'], '*')
-        assert_equal(res.headers['Access-Control-Max-Age'], '21600')
-        assert_true('HEAD' in res.headers['Access-Control-Allow-Methods'])
-        assert_true('POS' in res.headers['Access-Control-Allow-Methods'])
-        assert_true('GET' in res.headers['Access-Control-Allow-Methods'])
-        assert_true('OPTIONS' in res.headers['Access-Control-Allow-Methods'])
-        assert_true('CONTENT-TYPE' in res.headers['Access-Control-Allow-Headers'])
+        assert_equal(res.headers['Access-Control-Allow-Origin'], 'foo.com')
+
+        # test CORS gets set properly in failures
+        res = self.client.post(url,
+                               data=data,
+                               headers={"Origin": "foo.com"},
+                               content_type='application/json')
+        assert_equal(res.status_code, 400)
+        assert_equal(res.headers['Access-Control-Allow-Origin'], 'foo.com')
 
     def test_get_adgroups_by_campaign_id(self):
         """ Test for getting all adgroups for a given campaign id

--- a/tests/api/test_tile.py
+++ b/tests/api/test_tile.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equal, assert_true
+from nose.tools import assert_equal
 from flask import url_for, json
 from tests.base import BaseTestCase
 from tests.populate_database import parse_csv
@@ -28,15 +28,20 @@ class TestTile(BaseTestCase):
         """Test the support for CORS"""
         url = url_for('api.tile.tiles')
         data = json.dumps(self.new_tile)
-        res = self.client.post(url, data=data, content_type='application/json')
+        res = self.client.post(url,
+                               data=data,
+                               headers={"Origin": "foo.com"},
+                               content_type='application/json')
         assert_equal(res.status_code, 201)
-        assert_equal(res.headers['Access-Control-Allow-Origin'], '*')
-        assert_equal(res.headers['Access-Control-Max-Age'], '21600')
-        assert_true('HEAD' in res.headers['Access-Control-Allow-Methods'])
-        assert_true('POS' in res.headers['Access-Control-Allow-Methods'])
-        assert_true('GET' in res.headers['Access-Control-Allow-Methods'])
-        assert_true('OPTIONS' in res.headers['Access-Control-Allow-Methods'])
-        assert_true('CONTENT-TYPE' in res.headers['Access-Control-Allow-Headers'])
+        assert_equal(res.headers['Access-Control-Allow-Origin'], 'foo.com')
+
+        # test CORS gets set properly in failures
+        res = self.client.post(url,
+                               data=data,
+                               headers={"Origin": "foo.com"},
+                               content_type='application/json')
+        assert_equal(res.status_code, 400)
+        assert_equal(res.headers['Access-Control-Allow-Origin'], 'foo.com')
 
     def test_get_tiles_by_adgroup_id(self):
         """ Test for getting all tiles for a given adgroup id


### PR DESCRIPTION
Add Flask-Cors library to support CORS, the built-in support from Flask-Restful can't handle the failure cases properly.