### PR TITLE
Unify time format to ISO8601

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ bleach==1.4.1
 tld==0.7.3
 flask-restful==0.3.4
 Flask-Cors==2.1.0
+pytz==2015.6

--- a/splice/models.py
+++ b/splice/models.py
@@ -1,4 +1,6 @@
+import pytz
 from splice.environment import Environment
+
 
 db = Environment.instance().db
 metadata = db.metadata
@@ -16,12 +18,20 @@ class Account(db.Model):
     campaigns = db.relationship("Campaign", backref="account")
 
 
+class UTCAwareDateTime(db.TypeDecorator):
+    '''UTC aware datetime, not naive ones.'''
+    impl = db.DateTime
+
+    def process_result_value(self, value, dialect):
+        return value.replace(tzinfo=pytz.utc)
+
+
 class Campaign(db.Model):
     __tablename__ = "campaigns"
 
     id = db.Column('id', db.Integer(), autoincrement=True, primary_key=True, info={"identity": [1, 1]})
-    start_date = db.Column('start_date', db.DateTime(), nullable=True)
-    end_date = db.Column('end_date', db.DateTime(), nullable=True)
+    start_date = db.Column('start_date', UTCAwareDateTime(timezone=True), nullable=True)
+    end_date = db.Column('end_date', UTCAwareDateTime(timezone=True), nullable=True)
     name = db.Column('name', db.String(length=255), nullable=False)
     paused = db.Column('paused', db.Boolean(), nullable=False, default=False)
     channel_id = db.Column('channel_id', db.Integer(), db.ForeignKey("channels.id"))

--- a/splice/web/api/account.py
+++ b/splice/web/api/account.py
@@ -14,7 +14,7 @@ api = Api(account_bp)
 account_fields = {
     'id': fields.Integer,
     'name': fields.String,
-    'created_at': fields.DateTime,
+    'created_at': fields.DateTime(dt_format='iso8601'),
     'contact_name': fields.String,
     'contact_email': fields.String,
     'contact_phone': fields.String,

--- a/splice/web/api/adgroup.py
+++ b/splice/web/api/adgroup.py
@@ -25,7 +25,7 @@ adgroup_fields = {
     'frequency_cap_daily': fields.Integer,
     'frequency_cap_total': fields.Integer,
     'paused': fields.Boolean,
-    'created_at': fields.DateTime
+    'created_at': fields.DateTime(dt_format='iso8601')
 }
 
 

--- a/splice/web/api/campaign.py
+++ b/splice/web/api/campaign.py
@@ -1,7 +1,5 @@
-from datetime import datetime
-
 from flask import Blueprint
-from flask_restful import Api, Resource, marshal, fields, reqparse
+from flask_restful import Api, Resource, marshal, fields, reqparse, inputs
 from sqlalchemy.exc import IntegrityError
 
 from sqlalchemy.orm.exc import NoResultFound
@@ -17,9 +15,9 @@ campaign_fields = {
     'id': fields.Integer,
     'name': fields.String,
     'countries': fields.List(fields.String),
-    'created_at': fields.DateTime,
-    'start_date': fields.DateTime,
-    'end_date': fields.DateTime,
+    'created_at': fields.DateTime(dt_format='iso8601'),
+    'start_date': fields.DateTime(dt_format='iso8601'),
+    'end_date': fields.DateTime(dt_format='iso8601'),
     'paused': fields.Boolean,
     'channel_id': fields.Integer,
     'account_id': fields.Integer,
@@ -33,10 +31,10 @@ campaign_parser.add_argument(
 campaign_parser.add_argument(
     'countries', type=list, required=True, default=["STAR"], help='List of countries', location='json')
 campaign_parser.add_argument(
-    'start_date', type=datetime, required=False, help='Start date', location='json',
+    'start_date', type=inputs.datetime_from_iso8601, required=False, help='Start date', location='json',
     store_missing=False)
 campaign_parser.add_argument(
-    'end_date', type=datetime, required=False, help='End date', location='json',
+    'end_date', type=inputs.datetime_from_iso8601, required=False, help='End date', location='json',
     store_missing=False)
 campaign_parser.add_argument(
     'paused', type=bool, required=True, help='Campaign status', location='json',

--- a/splice/web/api/tile.py
+++ b/splice/web/api/tile.py
@@ -23,7 +23,7 @@ tile_fields = {
     'status': fields.String,
     'image_uri': fields.String,
     'enhanced_image_uri': fields.String,
-    'created_at': fields.DateTime,
+    'created_at': fields.DateTime(dt_format='iso8601'),
     'bg_color': fields.String,
     'paused': fields.Boolean,
     'title_bg_color': fields.String

--- a/tests/fixtures/campaigns.csv
+++ b/tests/fixtures/campaigns.csv
@@ -1,5 +1,5 @@
-name,paused,channel_id,account_id
-MozDirectory,false,1,1
-MozSuggested,false,3,1
-BookingDirectory,false,1,2
-YahooSuggested,false,3,3
+name,paused,channel_id,account_id,start_date,end_date
+MozDirectory,false,1,1,2015-09-30T16:06:55+00:00,2015-10-30T16:06:55+00:00
+MozSuggested,false,3,1,2015-09-10T16:06:55+00:00,2015-10-23T16:06:55+00:00
+BookingDirectory,false,1,2,2015-09-23T11:04:55+00:00,2015-10-5T11:04:55+00:00
+YahooSuggested,false,3,3,2015-10-03T14:04:55+00:00,2015-11-20T10:04:55+00:00


### PR DESCRIPTION
This PR intends to unify the time format for all SP2 models. See #142 .

**NOTE:** you might need to set the `timezone` for your Postgresql to 'UTC'. Otherwise, it'll automatically do the conversion regardless the timezone you've passed to it.
 
In your `postgresql.conf`, search `timezone` and replace it with 'UTC'. It's already configured properly in production.