### PR TITLE
Add support APIs for channel, country, and locale

### DIFF
--- a/migrations/versions/16fa35dd63a2_.py
+++ b/migrations/versions/16fa35dd63a2_.py
@@ -14,6 +14,7 @@ depends_on = None
 
 from alembic import op
 import sqlalchemy as sa
+from splice.environment import Environment
 
 
 def upgrade(engine_name):
@@ -25,6 +26,12 @@ def downgrade(engine_name):
 
 
 
+def populate_countries(table):
+    countries = Environment.instance()._load_countries()
+    op.bulk_insert(
+        table,
+        [{"country_code": code, "country_name": name} for code, name in countries]
+    )
 
 
 def upgrade_():
@@ -38,11 +45,12 @@ def upgrade_():
     sa.Column('created_at', sa.DateTime(), server_default=sa.text(u'now()'), nullable=False),
     sa.PrimaryKeyConstraint('id')
     )
-    op.create_table('countries',
+    table_countries = op.create_table('countries',
     sa.Column('country_code', sa.String(length=255), nullable=False),
     sa.Column('country_name', sa.String(length=255), nullable=True),
     sa.PrimaryKeyConstraint('country_code')
     )
+    populate_countries(table_countries)
     op.create_table('campaigns',
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('locale', sa.String(length=14), nullable=False),

--- a/splice/environment.py
+++ b/splice/environment.py
@@ -131,8 +131,8 @@ class Environment(object):
         with open(self.config.COUNTRY_FIXTURE_PATH, 'rb') as f:
             reader = csv.reader(f)
             data = [line for line in reader]
-        data.append(("ERROR", "ERROR"))
-        data.append(("STAR", "All Countries"))
+        data.append(["STAR", "All Countries"])
+        data.append(["ERROR", "ERROR"])
         return data
 
     def _load_fixtures(self):

--- a/splice/web/api/init.py
+++ b/splice/web/api/init.py
@@ -1,0 +1,74 @@
+from flask import Blueprint
+from flask_restful import Api, Resource, marshal, fields
+from splice.environment import Environment
+from splice.queries.common import get_channels
+
+
+init_bp = Blueprint('api.init', __name__, url_prefix='/api')
+api = Api(init_bp)
+
+country_fields = {
+    'country_code': fields.String,
+    'country_name': fields.String,
+}
+
+locale_fields = {
+    "results": fields.List(fields.String),
+}
+
+channel_fields = {
+    'id': fields.Integer,
+    'name': fields.String,
+    'created_at': fields.DateTime(dt_format='iso8601'),
+}
+
+all_fields = {
+    "countries": fields.List(fields.Nested(country_fields)),
+    "locales": fields.List(fields.String),
+    "channels": fields.List(fields.Nested(channel_fields))
+}
+
+
+class InitAPI(Resource):
+    def __init__(self):
+        super(InitAPI, self).__init__()
+
+    def get(self, target):
+        """Returns the init data including locales, countries, channels etc.
+
+        Params: target string, [all|locales|countries|channels]
+        """
+        target = target.lower()
+        if target == "all":
+            locales = Environment.instance()._load_locales()[:-1]
+            locales.sort()
+            countries = Environment.instance()._load_countries()[:-1]
+            country_items = [{"country_code": code, "country_name": name} for code, name in countries]
+            channels = get_channels()
+            data = {
+                "countries": country_items,
+                "channels": channels,
+                "locales": locales
+            }
+            return {'result': marshal(data, all_fields)}
+        elif target == "locales":
+            # the last item is 'ERROR', client won't need this
+            locales = Environment.instance()._load_locales()[:-1]
+            locales.sort()
+            return marshal({"results": locales}, locale_fields)
+        elif target == "countries":
+            # the last item is 'ERROR', client won't need this
+            countries = Environment.instance()._load_countries()[:-1]
+            country_items = [{"country_code": code, "country_name": name} for code, name in countries]
+            return {'results': marshal(country_items, country_fields)}
+        elif target == "channels":
+            channels = get_channels()
+            return {'results': marshal(channels, channel_fields)}
+        else:
+            return {"message": "Unknown target, must be one of [all|locales|countries|channels]"}, 404
+
+api.add_resource(InitAPI, '/init/<string:target>', endpoint='init')
+
+
+def register_routes(app):
+    app.register_blueprint(init_bp)

--- a/splice/webapp.py
+++ b/splice/webapp.py
@@ -15,6 +15,9 @@ def setup_routes(app):
     splice.web.api.heartbeat.register_routes(app)
 
     if not register_flask_restful:
+        import splice.web.api.init
+        splice.web.api.init.register_routes(app)
+
         import splice.web.api.account
         splice.web.api.account.register_routes(app)
 

--- a/tests/api/test_init.py
+++ b/tests/api/test_init.py
@@ -1,0 +1,73 @@
+
+from nose.tools import assert_equal
+from flask import url_for, json
+from tests.base import BaseTestCase
+from splice.environment import Environment
+from tests.populate_database import parse_csv
+
+
+class TestCountryLocale(BaseTestCase):
+    def test_get_all_locale(self):
+        """ Test for getting all locales"""
+        url = url_for('api.init.init', target="locales")
+        response = self.client.get(url)
+        assert_equal(response.status_code, 200)
+        locales = json.loads(response.data)['results']
+
+        locales_fixture = Environment.instance()._load_locales()[:-1]
+        locales_fixture.sort()
+        assert_equal(locales, locales_fixture)
+
+    def test_get_all_channels(self):
+        """ Test for getting all channels"""
+        url = url_for('api.init.init', target="channels")
+        response = self.client.get(url)
+        assert_equal(response.status_code, 200)
+        channels = json.loads(response.data)['results']
+
+        for i, channel in enumerate(parse_csv("channels.csv")):
+            channel_api = channels[i]
+            assert_equal(channel_api["name"], channel["name"])
+
+    def test_get_all_countries(self):
+        """ Test for getting all countries"""
+        url = url_for('api.init.init', target="countries")
+        response = self.client.get(url)
+        assert_equal(response.status_code, 200)
+        countries = json.loads(response.data)['results']
+
+        countries_fixture = Environment.instance()._load_countries()[:-1]
+        items = [{"country_code": code, "country_name": name} for code, name in countries_fixture]
+        assert_equal(countries, items)
+
+    def test_get_init(self):
+        """ Test for getting all init data"""
+        url = url_for('api.init.init', target="all")
+        response = self.client.get(url)
+        assert_equal(response.status_code, 200)
+        combo = json.loads(response.data)['result']
+
+        url = url_for('api.init.init', target="locales")
+        response = self.client.get(url)
+        assert_equal(response.status_code, 200)
+        locales = json.loads(response.data)['results']
+
+        url = url_for('api.init.init', target="countries")
+        response = self.client.get(url)
+        assert_equal(response.status_code, 200)
+        countries = json.loads(response.data)['results']
+
+        url = url_for('api.init.init', target="channels")
+        response = self.client.get(url)
+        assert_equal(response.status_code, 200)
+        channels = json.loads(response.data)['results']
+
+        assert_equal(combo["locales"], locales)
+        assert_equal(combo["channels"], channels)
+        assert_equal(combo["countries"], countries)
+
+    def test_get_unknown(self):
+        """ Test for getting unknown init data"""
+        url = url_for('api.init.init', target="unknown")
+        response = self.client.get(url)
+        assert_equal(response.status_code, 404)


### PR DESCRIPTION
This PR adds an API endpoint to support the campaign&adgroup management. Specifically, it exposes `/api/init/<string:target>`, in which `target` could be one of,
* "countries", all the country codes and country names
* "locales", all the locales served in Firefox
* "channels", all the channels and the related channel_ids
* "all", get all of targets above


**Note** that all of those targets are read-only, therefore, only HTTP GET method is available for now. 