### PR TITLE
Use the dev bucket by default

### DIFF
--- a/splice/default_settings.py
+++ b/splice/default_settings.py
@@ -40,7 +40,7 @@ class DefaultConfig(object):
     }
 
     S3 = {
-        "bucket": "moz-tiles-local",
+        "bucket": "moz-tiles-dev",
         "tile_index_key": "tile_index.v3.json"
     }
 


### PR DESCRIPTION
In Sp2, we should always use the dev bucket on S3 by default. Nobody should touch the bucket for production in any case.

This is safer than letting developers overwrite the bucket in their `localconfig.py`. Also, we always explicitly set the bucket name in production, the dev bucket would be overwritten at that point. 