### PR TITLE
Ingest from the database directly

### DIFF
--- a/splice/models.py
+++ b/splice/models.py
@@ -62,6 +62,7 @@ class Channel(db.Model):
     id = db.Column(db.Integer(), autoincrement=True, primary_key=True, info={"identity": [1, 1]})
     name = db.Column(db.String(32), nullable=False, unique=True)
     created_at = db.Column(db.DateTime(), server_default=db.func.now())
+    adgroups = db.relationship("Adgroup", backref="channel")
 
 
 class Distribution(db.Model):

--- a/splice/queries/distribution.py
+++ b/splice/queries/distribution.py
@@ -115,7 +115,7 @@ def get_possible_distributions(today=None):
             "data": ag,
         })
 
-        tile_index_channel = tile_index.setdefault(channel, {})
+        tile_index_channel = tile_index.setdefault(channel, {'__ver__': 3})
         tile_index_channel[country_locale] = {
             'legacy': os.path.join(env.config.CLOUDFRONT_BASE_URL, legacy_key),
             'ag': os.path.join(env.config.CLOUDFRONT_BASE_URL, ag_key),
@@ -125,6 +125,7 @@ def get_possible_distributions(today=None):
     for channel, tile_index_channel in tile_index.items():
         artifacts[channel].append({
             "key": "{0}_{1}".format(channel, env.config.S3["tile_index_key"]),
-            "data": json.dumps(tile_index_channel, sort_keys=True)
+            "data": json.dumps(tile_index_channel, sort_keys=True),
+            "force_upload": True
         })
     return artifacts

--- a/splice/queries/distribution.py
+++ b/splice/queries/distribution.py
@@ -114,15 +114,17 @@ def get_possible_distributions(today=None):
             "key": ag_key,
             "data": ag,
         })
-        tile_index[country_locale] = {
+
+        tile_index_channel = tile_index.setdefault(channel, {})
+        tile_index_channel[country_locale] = {
             'legacy': os.path.join(env.config.CLOUDFRONT_BASE_URL, legacy_key),
             'ag': os.path.join(env.config.CLOUDFRONT_BASE_URL, ag_key),
         }
 
-        # the index file
+    # the index files
+    for channel, tile_index_channel in tile_index.items():
         artifacts[channel].append({
             "key": "{0}_{1}".format(channel, env.config.S3["tile_index_key"]),
-            "data": json.dumps(tile_index, sort_keys=True)
+            "data": json.dumps(tile_index_channel, sort_keys=True)
         })
-
     return artifacts

--- a/splice/queries/distribution.py
+++ b/splice/queries/distribution.py
@@ -52,7 +52,7 @@ def switch_to_cdn_url(image_uri):
     return os.path.join(env.config.CLOUDFRONT_BASE_URL, "images/%s" % basename)
 
 
-def get_possible_distributions(today=None):
+def get_possible_distributions(today=None, channel_id=None):
     from splice.environment import Environment
 
     env = Environment.instance()
@@ -71,6 +71,9 @@ def get_possible_distributions(today=None):
         .join(Campaign)
         .join(CampaignCountry)
         .order_by(Tile.id))
+
+    if channel_id is not None:
+        query = query.filter(Campaign.channel_id == channel_id)
 
     rows = query.all()
     bucketer = load_bucketer()
@@ -104,7 +107,7 @@ def get_possible_distributions(today=None):
         legacy_key = "{0}/{1}.{2}.json".format(channel, country_locale, legacy_hsh)
         artifacts[channel].append({
             "key": legacy_key,
-            "data": legacy})
+            "data": legacy_json})
 
         # v3
         ag = json.dumps({'suggested': suggested, 'directory': directory}, sort_keys=True)

--- a/splice/queries/distribution.py
+++ b/splice/queries/distribution.py
@@ -1,0 +1,113 @@
+from collections import defaultdict
+from collections import namedtuple
+import hashlib
+import os
+import urllib
+
+from datetime import datetime
+import json
+
+from splice.models import Tile, Adgroup, Campaign, CampaignCountry
+
+Dists = namedtuple("Dists", ['legacy', 'directory', 'suggested'])
+
+
+def _tile_dict(tile, legacy=False):
+        tile_dict = dict(
+            target_url=tile.target_url,
+            bg_color=tile.bg_color,
+            title_bg_color=tile.title_bg_color,
+            title=tile.title,
+            typ=tile.type,
+            image_uri=tile.image_uri,
+            enhanced_image_uri=tile.enhanced_image_uri,
+            locale=tile.adgroup.locale,
+            channel_id=tile.adgroup.channel_id)
+        if not legacy:
+            frequency_caps = {"daily": tile.adgroup.frequency_cap_daily, "total": tile.adgroup.frequency_cap_total}
+            #todo populate frecent_sites, adgroup_name
+            tile_dict.update(dict(
+                frecent_sites=None,
+                # time_limits=time_limits,
+                frequency_caps=frequency_caps,
+                adgroup_name=None,
+                adgroup_categories=tile.adgroup.categories,
+                explanation=tile.adgroup.explanation,
+                check_inadjacency=tile.adgroup.check_inadjacency))
+        return tile_dict
+
+
+def get_possible_distributions(today=None):
+    from splice.environment import Environment
+
+    env = Environment.instance()
+    if today is None:
+        today = datetime.utcnow().date()
+
+    query = (
+        env.db.session
+        .query(Tile)
+        .filter(Tile.paused == False)
+        .filter(Adgroup.paused == False)
+        .filter(Campaign.paused == False)
+        .filter(Campaign.end_date > today)
+        .filter(Campaign.start_date <= today)
+        .join(Adgroup)
+        .join(Campaign)
+        .join(CampaignCountry)
+        .order_by(Tile.id))
+
+    rows = query.all()
+
+    artifacts = defaultdict(list)
+    tiles = {}
+    for tile in rows:
+        locale = tile.adgroup.locale
+        countries = tile.adgroup.campaign.countries
+        channel = tile.adgroup.channel.name
+        safe_channel_name = urllib.quote(channel)
+
+        tile_dict = _tile_dict(tile)
+        legacy_dict = _tile_dict(tile, True)
+        suggested = len(tile.adgroup.categories) > 0
+
+        for country in countries:
+            key = (safe_channel_name, country, locale)
+            value = tiles.setdefault(key, Dists(legacy=[], directory=[], suggested=[]))
+            if suggested:
+                value.suggested.append(tile_dict)
+            else:
+                value.directory.append(tile_dict)
+                value.legacy.append(legacy_dict)
+
+    tile_index = {}
+    for (channel, country, locale), (legacy, directory, suggested) in tiles.items():
+        country_locale = "%s/%s" % (country, locale)
+        # do v2
+        legacy_json = json.dumps({locale: legacy}, sort_keys=True)
+        legacy_hsh = hashlib.sha1(legacy_json).hexdigest()
+        legacy_key = "{0}/{1}.{2}.json".format(channel, country_locale, legacy_hsh)
+        artifacts[channel].append({
+            "key": legacy_key,
+            "data": legacy})
+
+        # v3
+        ag = json.dumps({'suggested': suggested, 'directory': directory}, sort_keys=True)
+        ag_hsh = hashlib.sha1(ag).hexdigest()
+        ag_key = "{0}/{1}.{2}.ag.json".format(channel, country_locale, ag_hsh)
+        artifacts[channel].append({
+            "key": ag_key,
+            "data": ag,
+        })
+        tile_index[country_locale] = {
+            'legacy': os.path.join(env.config.CLOUDFRONT_BASE_URL, legacy_key),
+            'ag': os.path.join(env.config.CLOUDFRONT_BASE_URL, ag_key),
+        }
+
+    return artifacts
+
+
+
+
+
+

--- a/splice/queries/distribution.py
+++ b/splice/queries/distribution.py
@@ -121,7 +121,7 @@ def get_possible_distributions(today=None):
 
         # the index file
         artifacts[channel].append({
-            "key": "{0}_{1}".format(safe_channel_name, env.config.S3["tile_index_key"]),
+            "key": "{0}_{1}".format(channel, env.config.S3["tile_index_key"]),
             "data": json.dumps(tile_index, sort_keys=True)
         })
 

--- a/splice/web/api/distribution.py
+++ b/splice/web/api/distribution.py
@@ -1,0 +1,52 @@
+from flask import Blueprint
+from flask_restful import Api, Resource, reqparse, inputs
+from splice.queries.distribution import get_possible_distributions
+from splice.web.api.tile_upload import artifacts_upload
+
+
+dist_bp = Blueprint('api.distributions', __name__, url_prefix='/api')
+api = Api(dist_bp)
+
+arg_parser = reqparse.RequestParser()
+arg_parser.add_argument(
+    'date', type=inputs.date, required=False, help='date',
+    location='args', store_missing=False)
+arg_parser.add_argument(
+    'channel_id', type=int, required=False, help='Channel ID',
+    location='args', store_missing=False)
+
+
+class DistributionAPI(Resource):
+    def __init__(self):
+        super(DistributionAPI, self).__init__()
+
+    def get(self):
+        """Returns the distributions on a specific date"""
+        args = arg_parser.parse_args()
+        artifacts = get_possible_distributions(today=args.get('date'),
+                                               channel_id=args.get('channel_id'))
+        if artifacts:
+            return {"results": artifacts}
+        else:
+            return {"message": "No ditribution found on that date"}, 404
+
+    def post(self):  # progma: no cover
+        """Deploy the current distribution to S3"""
+        ret = {}
+        args = arg_parser.parse_args()
+        try:
+            channel_artifacts = get_possible_distributions(today=args.get('date'),
+                                                           channel_id=args.get('channel_id'))
+            for channel, artifacts in channel_artifacts.items():
+                urls = artifacts_upload(artifacts)
+                ret[channel] = urls
+            return {"results": ret}, 201
+        except Exception as e:
+            return {"message": "%s" % e}, 400
+
+
+api.add_resource(DistributionAPI, '/distributions', endpoint='distributions')
+
+
+def register_routes(app):
+    app.register_blueprint(dist_bp)

--- a/splice/webapp.py
+++ b/splice/webapp.py
@@ -33,6 +33,9 @@ def setup_routes(app):
         import splice.web.api.reporting
         splice.web.api.reporting.register_routes(app)
 
+        import splice.web.api.distribution
+        splice.web.api.distribution.register_routes(app)
+
         register_flask_restful = True
 
 

--- a/tests/api/test_distribution.py
+++ b/tests/api/test_distribution.py
@@ -1,0 +1,60 @@
+import mock
+
+from tests.base import BaseTestCase
+from nose.tools import assert_equal
+from flask import url_for, json
+
+
+class TestDistributionAPI(BaseTestCase):
+    def test_get_all_distributions(self):
+        url = url_for('api.distributions.distributions', date="2015-10-01")
+        response = self.client.get(url)
+        assert_equal(response.status_code, 200)
+        resp = json.loads(response.data)["results"]
+        assert_equal(set(resp.keys()), set(["desktop", "desktop-prerelease"]))
+        # desktop channel: 3 country_locals * 2 versions + 1 index file
+        # prerelease channel: 1 country_locals * 2 versions + 1 index file
+        total = 0
+        for _, artifacts in resp.items():
+            total += len(artifacts)
+        assert_equal(total, 10)
+
+    def test_get_all_distributions_channel_id(self):
+        url = url_for('api.distributions.distributions', date="2015-10-01", channel_id=1)
+        response = self.client.get(url)
+        assert_equal(response.status_code, 200)
+        resp = json.loads(response.data)["results"]
+        assert_equal(set(resp.keys()), set(["desktop"]))
+        # desktop channel: 3 country_locals * 2 versions + 1 index file
+        total = 0
+        for _, artifacts in resp.items():
+            total += len(artifacts)
+        assert_equal(total, 7)
+
+        url = url_for('api.distributions.distributions', date="2015-10-01", channel_id=3)
+        response = self.client.get(url)
+        assert_equal(response.status_code, 200)
+        resp = json.loads(response.data)["results"]
+        assert_equal(set(resp.keys()), set(["desktop-prerelease"]))
+        # prerelease channel: 1 country_locals * 1 versions + 1 index file
+        total = 0
+        for _, artifacts in resp.items():
+            total += len(artifacts)
+        assert_equal(total, 3)
+
+    def test_get_all_distributions_failure(self):
+        url = url_for('api.distributions.distributions', date="2000-10-01")
+        response = self.client.get(url)
+        assert_equal(response.status_code, 404)
+
+    def test_post_all_distributions(self):
+        url = url_for('api.distributions.distributions', date="2000-10-01")
+        response = self.client.post(url)
+        assert_equal(response.status_code, 201)
+
+    @mock.patch('splice.queries.distribution.get_possible_distributions')
+    def test_post_all_distributions_failure(self, query_mock):
+        query_mock.side_effect = ValueError("cannot connect to database")
+        url = url_for('api.distributions.distributions', date="2015-10-01")
+        response = self.client.post(url)
+        assert_equal(response.status_code, 400)

--- a/tests/fixtures/adgroups.csv
+++ b/tests/fixtures/adgroups.csv
@@ -2,9 +2,9 @@ name,locale,type,paused,campaign_id,channel_id
 MDN,en-US,directory,false,1,1
 Pocket for Firefox,en-US,directory,false,1,1
 Hello,en-US,directory,false,1,1
-MDN,en-US,suggested,false,2,1
-Pocket for Firefox,en-US,suggested,false,2,1
+MDN,en-US,suggested,false,2,3
+Pocket for Firefox,en-US,suggested,false,2,3
 BookingEN,en-US,directory,false,3,1
 BookingES,es,directory,false,3,1
 BookingFR,fr,directory,false,3,1
-YahooEN,en-US,suggested,false,4,1
+YahooEN,en-US,suggested,false,4,3


### PR DESCRIPTION
This PR intends to replace the JSON based tile generation. It fetches all the tiles from the database based on the campaigns' flight date. Then it groups tiles by channels, country, and locales, generating the index files accordingly. The file format is backward compatible with the current Version 3 one. The only difference is it'll contain all the tiles instead of only one sponsored tile in the current distribution.

Two API endpoints are exposed here:
HTTP GET   /api/distributions\?channel_id=3\&date="2015-10-10"
HTTP POST /api/distributions

Where the GET returns the index files in JSON, and POST pushes all the index files to S3