### PR TITLE
Issue 108 multiplex directory tiles

### DIFF
--- a/splice/queries/distribution.py
+++ b/splice/queries/distribution.py
@@ -173,11 +173,14 @@ def multiplex_directory_tiles(tiles):
     """Directory tile multiplexer that creates all possible combinations of the
     tile sets based on its type and the target url. Given multiple sponsored tiles,
     it'll pick one of them and create a new tile set with other directory tiles.
-    It also multiplexes the tiles with the same TLD+1 target url (e.g. www.mozilla.org).
-    Therefore, given a tile set with N sponsored tiles and M identical TLD+1 tiles, the
+    It also multiplexes the tiles with the same Full Qualified Domain Name(FQDN).
+    For example, "https://www.mozilla.org/pocket" and "https://www.mozilla.org/gears"
+    share the same FQDN "www.mozilla.org".
+
+    Therefore, given a tile set with N sponsored tiles and M identical FQDN tiles, the
     total number of multiplexed directory tile set is N*M.
 
-    Note: this function will NOT handle the same tld+1 URL between the sponsored and
+    Note: this function will NOT handle the same FQDN between the sponsored and
     non-sponsered tiles.
 
     Params:
@@ -187,21 +190,21 @@ def multiplex_directory_tiles(tiles):
         3rd entry in the list, other tiles will be sorted by the tile id.
     """
     sponsored = []
-    tlds = defaultdict(list)
+    fqdns = defaultdict(list)
     for tile in tiles:
         if tile["type"] == "sponsored":
             sponsored.append(tile)
         else:
             url = furl(tile["url"]).netloc
             assert url, "URL: %s is invalid" % tile["url"]
-            tlds[url].append(tile)
+            fqdns[url].append(tile)
 
     # if no sponsored tiles found, use a sentinel instead
     if not sponsored:
         sponsored.append(_SENTINEL)
 
-    # Cartesian product of the identical tld tiles and the sponsored tiles
-    for multiplex in product(sponsored, *tlds.values()):
+    # Cartesian product of the identical FQDN tiles and the sponsored tiles
+    for multiplex in product(sponsored, *fqdns.values()):
         copy = list(multiplex)
         sponsored_tile, rest = copy[0], copy[1:]
         rest.sort(key=lambda tile: tile["directoryId"])

--- a/splice/queries/distribution.py
+++ b/splice/queries/distribution.py
@@ -149,8 +149,8 @@ def get_possible_distributions(today=None, channel_id=None):
             })
 
         tile_index_channel = tile_index.setdefault(channel, {'__ver__': 3})
-        all_legacy_keys = [os.path.join(env.config.CLOUDFRONT_BASE_URL, key) for key in legacy_keys]
-        all_ag_keys = [os.path.join(env.config.CLOUDFRONT_BASE_URL, key) for key in ag_keys]
+        all_legacy_keys = [os.path.join(env.config.CLOUDFRONT_BASE_URL, k) for k in legacy_keys]
+        all_ag_keys = [os.path.join(env.config.CLOUDFRONT_BASE_URL, k) for k in ag_keys]
         tile_index_channel[country_locale] = {
             'legacy': all_legacy_keys,
             'ag': all_ag_keys

--- a/splice/queries/distribution.py
+++ b/splice/queries/distribution.py
@@ -6,7 +6,9 @@ import json
 from datetime import datetime
 from collections import defaultdict
 from collections import namedtuple
+from itertools import product
 
+from furl import furl
 from sqlalchemy.sql.expression import false
 from splice.models import Tile, Adgroup, Campaign, CampaignCountry
 from splice.web.api.tile_upload import load_bucketer
@@ -154,3 +156,48 @@ def get_possible_distributions(today=None, channel_id=None):
             "force_upload": True
         })
     return artifacts
+
+
+_SENTINEL = object()
+
+
+def multiplex_directory_tiles(tiles):
+    """Directory tile multiplexer that creates all possible combinations of the
+    tile sets based on its type and the target url. Given multiple sponsored tiles,
+    it'll pick one of them and create a new tile set with other directory tiles.
+    It also multiplexes the tiles with the same TLD+1 target url (e.g. www.mozilla.org).
+    Therefore, given a tile set with N sponsored tiles and M identical TLD+1 tiles, the
+    total number of multiplexed directory tile set is N*M.
+
+    Note: this function will NOT handle the same tld+1 URL between sponsored and
+    non-sponsered tiles.
+
+    Params:
+        tiles: a list of original tiles.
+    Return:
+        A list of tile sets. Note that the sponsored directory tile is always the
+        3rd entry in the list, other tiles will be sorted by the tile id.
+    """
+    sponsored = []
+    tlds = defaultdict(list)
+    for tile in tiles:
+        if tile["type"] == "sponsored":
+            sponsored.append(tile)
+        else:
+            url = furl(tile["url"]).netloc
+            assert url, "URL: %s is invalid" % tile["url"]
+            tlds[url].append(tile)
+
+    # if no sponsored tiles found, use a sentinel instead
+    if not sponsored:
+        sponsored.append(_SENTINEL)
+
+    # Cartesian product of the identical tld tiles and the sponsored tiles
+    for multiplex in product(sponsored, *tlds.values()):
+        copy = list(multiplex)
+        sponsored_tile, rest = copy[0], copy[1:]
+        rest.sort(key=lambda tile: tile["directoryId"])
+        # if the sponsored tile is not the sentinel, insert into tile list
+        if not (len(sponsored) == 1 and sponsored_tile is _SENTINEL):
+            rest.insert(2, sponsored_tile)  # sponsored tile always takes the 3rd place
+        yield rest

--- a/tests/api/test_distribution.py
+++ b/tests/api/test_distribution.py
@@ -3,6 +3,7 @@ import mock
 from tests.base import BaseTestCase
 from nose.tools import assert_equal
 from flask import url_for, json
+from splice.queries.distribution import multiplex_directory_tiles
 
 
 class TestDistributionAPI(BaseTestCase):
@@ -58,3 +59,39 @@ class TestDistributionAPI(BaseTestCase):
         url = url_for('api.distributions.distributions', date="2015-10-01")
         response = self.client.post(url)
         assert_equal(response.status_code, 400)
+
+    def test_multiplex_directory_tiles(self):
+        tile1 = {"type": "sponsored", "directoryId": 1, "url": "http://www.test.com"}
+        tile2 = {"type": "sponsored", "directoryId": 2, "url": "http://www.test1.com"}
+        tile3 = {"type": "affiliate", "directoryId": 3, "url": "http://www.mozilla.org"}
+        tile4 = {"type": "affiliate", "directoryId": 4, "url": "http://www.mozilla.org"}
+        tile5 = {"type": "affiliate", "directoryId": 5, "url": "http://developer.mozilla.org"}
+        tiles = [tile1, tile2, tile3, tile4, tile5]
+        ret = list(multiplex_directory_tiles(tiles))
+        assert_equal(len(ret), 4)
+        assert_equal([
+            [tile3, tile5, tile1],
+            [tile4, tile5, tile1],
+            [tile3, tile5, tile2],
+            [tile4, tile5, tile2]
+        ], ret)
+        ret = list(multiplex_directory_tiles(tiles[2:]))
+        assert_equal(len(ret), 2)
+        assert_equal([
+            [tile3, tile5],
+            [tile4, tile5]
+        ], ret)
+        ret = list(multiplex_directory_tiles([tile1, tile3, tile5]))
+        assert_equal(len(ret), 1)
+        assert_equal([
+            [tile3, tile5, tile1],
+        ], ret)
+        ret = list(multiplex_directory_tiles(tiles[:2]))
+        assert_equal(len(ret), 2)
+        assert_equal([
+            [tile1],
+            [tile2]
+        ], ret)
+        ret = list(multiplex_directory_tiles(tiles[:1]))
+        assert_equal(len(ret), 1)
+        assert_equal([[tile1]], ret)


### PR DESCRIPTION
This PR implements the feature for rotating directory tiles. See more details in #108 

You can use following API endpoints in your dev environment. Note that both `channel_id` and `date` are optional arguments. 

```shell
$ http GET :5000/api/distributions\?channel_id=1\&date="2015-10-04"
$ http POST :5000/api/distributions\?channel_id=1\&date="2015-10-04"
```
