### PR TITLE
New group_by fields for stats

### DIFF
--- a/splice/queries/common.py
+++ b/splice/queries/common.py
@@ -27,6 +27,10 @@ def row_to_dict(row):
     return {c.name: getattr(row, c.name) for c in row.__table__.columns}
 
 
+def tuple_to_dict(row):
+    return row._asdict()
+
+
 def get_frecent_sites_for_tile(tile_id, conn=None):
     stmt = (select([AdgroupSite.site])
             .where(and_(AdgroupSite.adgroup_id == Adgroup.id,

--- a/splice/queries/reporting.py
+++ b/splice/queries/reporting.py
@@ -1,11 +1,94 @@
 from splice.models import impression_stats_daily
-from splice.queries.tile import get_tiles
+from splice.queries.tile import get_tiles, get_tile_ids_by_group
 from sqlalchemy.sql import func
 from sqlalchemy.orm import aliased
 from sqlalchemy import case
+from splice.queries.common import tuple_to_dict
+from sqlalchemy.exc import InvalidRequestError
+
+CROSS_DB_COLUMNS = {
+    'account_id',
+    'campaign_id',
+    'adgroup_id',
+    'type',
+    'adgroup_type',
+    'category'
+}
+
+CROSS_DB_ERROR = 'You may only group by ONE of %s'
 
 
-def get_stats(group_by, filters=None):
+def build_subquery_table(env, stats_table, cross_db_group_by, group_by, filters=None):
+    """
+    Build a subquery for group_by fields that require groupings in mozsplice_campaigns
+    """
+    # Note: we only support one cross-db group-by at the moment
+    if (len(cross_db_group_by) > 1):
+        raise InvalidRequestError(CROSS_DB_ERROR % ' and '.join(cross_db_group_by))
+
+    group_by_field = cross_db_group_by[0]
+    grouped_tiles = get_tile_ids_by_group(group_by=group_by_field, filters=filters)
+
+    if not grouped_tiles:
+        return None
+
+    # flatten grouped_tiles
+    all_tiles = sum([group['tile_ids'] for group in grouped_tiles], [])
+
+    case_table = case(map(
+        (lambda item: (stats_table.c.tile_id.in_(item['tile_ids']), item[group_by_field])),
+        grouped_tiles
+    ))
+
+    subquery = (
+        env.db.session.query(
+            case_table.label(group_by_field),
+            *stats_table.c
+        )
+        .filter(stats_table.c.tile_id.in_(all_tiles))
+    ).subquery()
+
+    return subquery
+
+
+def build_base_query(env, group_by, base_table):
+    """
+    Build a basic query given a list of group_by fields and a base table
+    """
+    group_by_columns = [base_table.c[column] for column in group_by]
+
+    fields = group_by_columns + [
+        func.sum(base_table.c.impressions).label('impressions'),
+        func.sum(base_table.c.clicks).label('clicks'),
+        func.sum(base_table.c.pinned).label('pinned'),
+        func.sum(base_table.c.blocked).label('blocked')
+    ]
+
+    return (
+        env.db.session
+        .query(*fields)
+        .group_by(*group_by_columns)
+    )
+
+
+def add_filters(query, base_table, filters):
+    """
+    Adds filters to query
+    """
+    if 'tile_id' in filters:
+        query = query.filter(base_table.c.tile_id.in_(filters['tile_id']))
+    if 'country_code' in filters:
+        query = query.filter(base_table.c.country_code == filters['country_code'])
+    if 'locale' in filters:
+        query = query.filter(base_table.c.locale == filters['locale'])
+    if 'start_date' in filters:
+        query = query.filter(base_table.c.date >= filters['start_date'])
+    if 'end_date' in filters:
+        query = query.filter(base_table.c.date <= filters['end_date'])
+    return query
+
+
+def get_stats(group_by, filters=None, limit=60):
     """
     Get aggregated stats based on a list of group_by fields and filters
     """
@@ -13,78 +96,31 @@ def get_stats(group_by, filters=None):
     env = Environment.instance()
 
     isd = aliased(impression_stats_daily)
-    filters = filters or {}
     base_table = isd
-    tiles = []
-    group_by_columns = []
+    local_filters = filters.copy()
 
-    # Fields
-    if 'category' in group_by:
-        grouped_tiles = get_tiles(group_by='category', filters=filters)
-        if not grouped_tiles:
+    has_cross_db_filters = bool(CROSS_DB_COLUMNS.intersection(filters)) if filters else False
+    cross_db_group_by = list(CROSS_DB_COLUMNS.intersection(group_by))
+
+    # Build base table and list of tiles
+    if cross_db_group_by:
+        base_table = build_subquery_table(env=env, stats_table=isd, group_by=group_by,
+                                          cross_db_group_by=cross_db_group_by, filters=filters)
+        # No tiles were found, so no stats
+        if base_table is None:
             return None
-        for c in grouped_tiles:
-            for tile in c['tile_ids']:
-                tiles.append(tile)
 
-        category = case(map(
-            (lambda item: (isd.c.tile_id.in_(item['tile_ids']), item['category'])),
-            grouped_tiles
-        ))
-
-        other_groups = group_by[:]
-        other_groups.remove('category')
-        if 'date' in other_groups:
-            other_groups.remove('date')
-
-        base_table = (
-            env.db.session.query(
-                category.label('category'),
-                isd.c.date,
-                isd.c.tile_id,
-                isd.c.impressions,
-                isd.c.clicks,
-                isd.c.pinned,
-                isd.c.blocked,
-                *other_groups
-            )
-            .filter(isd.c.tile_id.in_(tiles))
-        ).subquery()
-    else:
-        tiles = get_tiles(limit_fields=['id'], filters=filters)
-        if not tiles:
+    elif has_cross_db_filters:
+        tiles_result = get_tiles(limit_fields=['id'], filters=filters)
+        # No tiles were found, so no stats
+        if not tiles_result:
             return None
-        else:
-            tiles = [t['id'] for t in tiles]
+        local_filters['tile_id'] = [t['id'] for t in tiles_result]
 
-    for column in group_by:
-        group_by_columns.append(base_table.c[column])
-
-    query = group_by_columns + [
-        func.sum(base_table.c.impressions).label('impressions'),
-        func.sum(base_table.c.clicks).label('clicks'),
-        func.sum(base_table.c.pinned).label('pinned'),
-        func.sum(base_table.c.blocked).label('blocked')
-    ]
-
-    # Base query
-    rows = (
-        env.db.session
-        .query(*query)
-        .group_by(*group_by_columns)
-        .order_by(group_by_columns[0])
-    )
-
-    # Filters
-    if 'category' not in group_by:
-        rows = rows.filter(base_table.c.tile_id.in_(tiles))
-    if 'country_code' in filters:
-        rows = rows.filter(base_table.c.country_code == filters['country_code'])
-    if 'start_date' in filters:
-        rows = rows.filter(base_table.c.date >= filters['start_date'])
-    if 'end_date' in filters:
-        rows = rows.filter(base_table.c.date <= filters['end_date'])
-
+    # Build query
+    rows = build_base_query(env=env, group_by=group_by, base_table=base_table)
+    rows = add_filters(query=rows, base_table=base_table, filters=local_filters)
+    rows = rows.order_by(base_table.c[group_by[0]]).limit(limit)
     rows = rows.all()
 
-    return [r._asdict() for r in rows] if rows else None
+    return [tuple_to_dict(r) for r in rows] if rows else None

--- a/tests/api/test_reporting.py
+++ b/tests/api/test_reporting.py
@@ -2,8 +2,23 @@ from tests.base import BaseTestCase
 
 from flask import url_for, json
 from nose.tools import assert_equal
+from splice.web.api.reporting import valid_group_by
 
 BASE_URL = 'api.reporting.stats'
+
+filter_examples = {
+    'account_id': 1,
+    'campaign_id': 1,
+    'adgroup_id': 1,
+    'type': 'affiliate',
+    'adgroup_type': 'directory',
+    'country_code': 'US',
+    'locale': 'en-US',
+    'channel_id': 1,
+    'start_date': '2015-09-01',
+    'end_date': '2015-10-30',
+    'tile_id': [1, 2, 3]
+}
 
 
 class TestReportingAPI(BaseTestCase):
@@ -17,9 +32,7 @@ class TestReportingAPI(BaseTestCase):
             group_by_fields = [group_by]
         else:
             group_by_fields = group_by or ['date']
-        query = {'campaign_id': 1}
-        query.update(filters)
-        url = url_for(base_url, **query)
+        url = url_for(base_url, **filters)
 
         result = self.client.get(url)
 
@@ -44,37 +57,36 @@ class TestReportingAPI(BaseTestCase):
         date_resp = self.helper_test_set(filters={'group_by': 'date'})
         assert_equal(default_resp, date_resp)
 
-    def test_week_month(self):
-        """Test group by week, month"""
-        self.helper_test_set(filters={'group_by': 'week'})
-        self.helper_test_set(filters={'group_by': 'month'})
-
-    def test_locale(self):
-        """Test group by locale"""
-        self.helper_test_set(filters={'group_by': 'locale'})
-        self.helper_test_set(filters={'group_by': 'locale', 'country_code': 'US'})
-
-    def test_country(self):
-        """Test group by country_code"""
-        self.helper_test_set(filters={'group_by': 'country_code'})
-        self.helper_test_set(filters={'group_by': 'country_code', 'locale': 'en-US'})
-
-    def test_category(self):
-        """Test group by category"""
-        self.helper_test_set(filters={'group_by': 'category'})
-        self.helper_test_set(filters={'group_by': 'category', 'channel_id': 1})
-        self.helper_test_set(filters={'group_by': 'category', 'start_date': '2015-09-01', 'end_date': '2015-10-30'})
+    def test_group_by(self):
+        """Test all group by options"""
+        for column in valid_group_by.keys():
+            self.helper_test_set(filters={'group_by': column})
+            for k, v in filter_examples.iteritems():
+                filters = {'group_by': column}
+                filters[k] = v
+                self.helper_test_set(filters=filters)
 
     def test_group_by_multiple(self):
         """Test group by multiple categories"""
-        self.helper_test_set(filters={'group_by': ['date', 'category']})
-        self.helper_test_set(filters={'group_by': ['category', 'country_code', 'locale']})
-        self.helper_test_set(filters={'group_by': ['date', 'category'], 'locale': 'en-US'})
+        self.helper_test_set({'group_by': ['date', 'category']})
+        self.helper_test_set({'group_by': ['category', 'country_code', 'locale']})
+        self.helper_test_set({'group_by': ['date', 'category'], 'locale': 'en-US'})
 
     def test_reporting_stats_empty(self):
-        """Test reporting stats empty response"""
+        self.helper_test_set({'account_id': 1132321}, empty=True)
         self.helper_test_set({'campaign_id': 1132321}, empty=True)
         self.helper_test_set({'campaign_id': 5}, empty=True)
+        self.helper_test_set({'locale': 'foo'}, empty=True)
+        self.helper_test_set({'group_by': ['date', 'category'], 'channel_id': 1132321}, empty=True)
+        self.helper_test_set({'start_date': '2016-04-01'}, empty=True)
+
+    def test_multiple_cross_db_filter_error(self):
+        """Test reporting stats empty response"""
+        url = url_for(BASE_URL, group_by=['category', 'adgroup_id'])
+        result = self.client.get(url)
+        assert_equal(result.status_code, 400)
+        resp = json.loads(result.data)
+        assert_equal(resp['message'], 'You may only group by ONE of category and adgroup_id')
 
     def test_reporting_undefined_filter(self):
         """Should return 400 if an invalid filter is passed"""


### PR DESCRIPTION
Adds `campaign_id`, `account_id`, and `adgroup_id` to list of valid group_by fields in stats api.

E.g.

Request: `/api/stats?group_by=account_id`
Response
```js
{
    "results": [
        {
            "account_id": 1, 
            "blocked": 24, 
            "clicks": 1, 
            "impressions": 6141, 
            "pinned": 0
        }, 
        {
            "account_id": 2, 
            "blocked": 0, 
            "clicks": 0, 
            "impressions": 10, 
            "pinned": 0
        }
    ]
}
```

