### PR TITLE
Fix adgroup name null.

### DIFF
--- a/front_end/src/components/AdGroups/AdGroupList/AdGroupRow.js
+++ b/front_end/src/components/AdGroups/AdGroupList/AdGroupRow.js
@@ -8,7 +8,7 @@ export default class AdGroupRow extends Component {
     return (
       <tr>
         <td>{this.props.id}</td>
-        <td><Link to={'/adgroups/' + this.props.id}>{(this.props.name !== '' ) ? this.props.name : '(No Name)' }</Link></td>
+        <td><Link to={'/adgroups/' + this.props.id}>{(this.props.name) ? this.props.name : '(No Name)' }</Link></td>
         <td>{this.props.locale}</td>
         <td>{_.capitalize(this.props.type)}</td>
         <td className={'status ' + ((this.props.paused) ? 'paused' : 'active')}>{(this.props.paused) ? 'Paused' : 'Active'}</td>

--- a/front_end/src/components/App/Navigation/BreadCrumbs.js
+++ b/front_end/src/components/App/Navigation/BreadCrumbs.js
@@ -8,23 +8,19 @@ export default class BreadCrumbs extends Component {
     let name;
 
     if(isTile){
-      if(data.title !== undefined) {
-        if (data.title.trim() === '') {
-          name = '(No Title)';
-        }
-        else {
-          name = data.title;
-        }
+      if (data.title) {
+        name = data.title;
+      }
+      else {
+        name = '(No Title)';
       }
     }
     else {
-      if(data.name !== undefined){
-        if(data.name.trim() === ''){
-          name = '(No Name)';
-        }
-        else{
-          name = data.name;
-        }
+      if(data.name){
+        name = data.name;
+      }
+      else{
+        name = '(No Name)';
       }
     }
     return name;

--- a/front_end/src/components/Tiles/TileList/TileRow.js
+++ b/front_end/src/components/Tiles/TileList/TileRow.js
@@ -8,7 +8,7 @@ export default class TileRow extends Component {
 		return (
 			<tr>
 				<td>{this.props.id}</td>
-				<td><Link to={'/tiles/' + this.props.id}>{(this.props.title !== '' ) ? this.props.title : '(No Title)' }</Link></td>
+				<td><Link to={'/tiles/' + this.props.id}>{(this.props.title) ? this.props.title : '(No Title)' }</Link></td>
 				<td>{_.capitalize(this.props.type)}</td>
 				<td className={'status ' + ((this.props.paused) ? 'paused' : 'active')}>{(this.props.paused) ? 'Paused' : 'Active'}</td>
 				<td className={'status ' + this.props.status}>{_.capitalize(this.props.status)}</td>


### PR DESCRIPTION
r? @rlr @ncloudioj 

Code now checks for any false value for adgroup name and tile title. `undefined`, `null` or `""` 

Fixes #281 