### PR TITLE
Fix Tile Form throwing parsley.js error

### DIFF
--- a/front_end/src/components/Tiles/TileForm/TileForm.js
+++ b/front_end/src/components/Tiles/TileForm/TileForm.js
@@ -356,10 +356,14 @@ export default class TileForm extends Component {
   handleFormSubmit(e) {
     e.preventDefault();
 
-    const staticField = $('#static_image_placeholder').parsley();
-    const rolloverField = $('#rollover_image_placeholder').parsley();
-    window.ParsleyUI.removeError(staticField, 'uploadError');
-    window.ParsleyUI.removeError(rolloverField, 'uploadError');
+    if($('#static_image_placeholder').length > 0){
+      const staticField = $('#static_image_placeholder').parsley();
+      window.ParsleyUI.removeError(staticField, 'uploadError');
+    }
+    if($('#rollover_image_placeholder').length > 0){
+      const rolloverField = $('#rollover_image_placeholder').parsley();
+      window.ParsleyUI.removeError(rolloverField, 'uploadError');
+    }
 
     $('input[name="account_id"], input[name="campaign_id"], input[name="adgroup_id"]')
       .attr('data-parsley-required', 'true');


### PR DESCRIPTION
The error is thrown because these fields do not exist in Edit mode, only when creating a new Tile. 